### PR TITLE
Add the ability to connect to a PSQL DB

### DIFF
--- a/myproject/__init__.py
+++ b/myproject/__init__.py
@@ -3,12 +3,19 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_restful import Api, Resource
+#cfrom myproject.config import dbpass
 
 app = Flask(__name__)
 
 app.config['SECRET_KEY'] = 'mysecretkey'
+###Configuration for sqlite DB
 basedir = os.path.abspath(os.path.dirname(__file__))
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(basedir, 'data.sqlite')
+
+
+###Configuration for Postgresql DB
+#Create a Database called brawlstars, User: application, password stored in dbpass variable in config.py
+#app.config['SQLALCHEMY_DATABASE_URI'] = f'postgresql://application:{dbpass}@localhost:5432/brawlstars'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 

--- a/myproject/example-config.py
+++ b/myproject/example-config.py
@@ -1,3 +1,6 @@
 #Please remember to rename this file config.py or rename the import in requester.py
 #Bearer should go infront of your API key per the Brawlstars API documentation
 key = "Bearer "
+
+##dbpass var is the Postgresql password and is imported in __init__.py
+dbpass = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Jinja2==2.10
 lazy==1.3
 Mako==1.0.7
 MarkupSafe==1.1.1
+psycopg2-binary==2.9.3
 python-dateutil==2.7.2
 python-editor==1.0.3
 requests==2.18.4


### PR DESCRIPTION
-Added psycopg2-binary dependency for PSQL
-Added SQLAlchemy config to connect to a PSQL DB
-Added var in config.py for DB password

The PSQL config is commented out so that SQLite is the default. 